### PR TITLE
Improve timeout error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func handleRequest(conn net.Conn, redisClient *redis.Client) {
 	for {
 		n, err := conn.Read(buf)
 		if err != nil {
-			if err != io.EOF && !strings.Contains(err.Error(), "i/o timeout") {
+			if netErr, _ := err.(net.Error); err != io.EOF && !netErr.Timeout() {
 				fmt.Println("read error:", err)
 				conn.Write([]byte("read err\r\n"))
 				conn.Close()


### PR DESCRIPTION
Checks for the actual net.Timeout error instead of relying on a string comparison.