### PR TITLE
feat: add rate limiting to HTTP GET requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ too much data`))
 
 func getIdentifier(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	// Rate limit: 1 request per second per IP
-	cip := strings.Split(r.RemoteAddr, ":")[0]
+	cip, _, _ := net.SplitHostPort(r.RemoteAddr)
 	limiter := rate.NewLimiter(rate.Every(time.Second), 1, "pastey_http_rl_"+cip)
 	if !limiter.Allow() {
 		w.Header().Set("Content-Type", "text/plain")


### PR DESCRIPTION
## Summary
- Adds rate limiting (1 request/second per IP) to HTTP GET requests for paste retrieval
- Uses existing Redis-backed rate limiter with key `pastey_http_rl_{ip}`
- Returns 429 Too Many Requests when limit exceeded