### PR TITLE
feat: add POST /create endpoint with secure option

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 
 	r.GET("/", indexPage)
 	r.GET("/:identifier", getIdentifier)
+	r.POST("/create", createPaste)
 
 	if err := http.ListenAndServe("0.0.0.0:3334", r); err != nil {
 		logrus.Error(err.Error())
@@ -119,6 +120,105 @@ func getIdentifier(w http.ResponseWriter, r *http.Request, ps httprouter.Params)
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte("not found or expired"))
 	}
+}
+
+func createPaste(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	// Rate limit: 1 paste per 5 seconds per IP
+	cip := strings.Split(r.RemoteAddr, ":")[0]
+	limiter := rate.NewLimiter(rate.Every(time.Second*5), 5, "pastey_http_create_rl_"+cip)
+	if !limiter.Allow() {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte("rate limit exceeded (1 paste per 5 seconds)"))
+		return
+	}
+
+	// Read body (max 5MB)
+	body, err := io.ReadAll(io.LimitReader(r.Body, 5000001))
+	if err != nil {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("error reading body"))
+		return
+	}
+	defer r.Body.Close()
+
+	if len(body) > 5000000 {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		w.Write([]byte("payload too big"))
+		return
+	}
+
+	if len(body) == 0 {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("empty body"))
+		return
+	}
+
+	// Check blacklist
+	for _, phrase := range BLACKLISTED_PHRASES {
+		if strings.Contains(string(body), phrase) {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte("blacklisted phrases, antispam system\ncontact admin@ig.lc if this is in error"))
+			return
+		}
+	}
+
+	// Determine identifier length: 32 chars if secure=true, otherwise 4
+	idLength := 4
+	if r.URL.Query().Get("secure") == "true" {
+		idLength = 32
+	}
+
+	// Generate unique identifier
+	identifier := ""
+	tried := 0
+	for {
+		identifier = randString(idLength)
+		val, err := client.Get("pastey_" + identifier).Result()
+		if err != nil {
+			if err == redis.Nil {
+				break
+			}
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("error"))
+			return
+		}
+		if val == "" {
+			break
+		}
+		identifier = ""
+		tried++
+		if tried > 5 {
+			break
+		}
+	}
+
+	if identifier == "" {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("could not generate identifier"))
+		return
+	}
+
+	// Store paste
+	result := client.Set("pastey_"+identifier, string(body), time.Hour*72)
+	if result.Err() != nil {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("error, could not connect to db"))
+		return
+	}
+
+	fmt.Println("made new paste " + identifier + " via HTTP POST from " + r.RemoteAddr)
+
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusCreated)
+	w.Write([]byte("https://ig.lc/" + identifier + "\n"))
 }
 
 func handleRequest(conn net.Conn) {

--- a/main.go
+++ b/main.go
@@ -124,8 +124,8 @@ func getIdentifier(w http.ResponseWriter, r *http.Request, ps httprouter.Params)
 
 func createPaste(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	// Rate limit: 1 paste per 5 seconds per IP
-	cip := strings.Split(r.RemoteAddr, ":")[0]
-	limiter := rate.NewLimiter(rate.Every(time.Second*5), 5, "pastey_http_create_rl_"+cip)
+	cip, _, _ := net.SplitHostPort(r.RemoteAddr)
+	limiter := rate.NewLimiter(rate.Every(time.Second*5), 1, "pastey_http_create_rl_"+cip)
 	if !limiter.Allow() {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusTooManyRequests)


### PR DESCRIPTION
## Summary
- Adds `POST /create` endpoint for creating pastes via HTTP
- Optional `?secure=true` query param generates 32-char identifier instead of 4
- Includes rate limiting (1 paste per 5 seconds per IP)
- Same validation as TCP: 5MB limit, blacklist filtering

## Usage
```bash
# Normal paste (4 char ID)
curl -X POST -d "hello world" https://ig.lc/create

# Secure paste (32 char ID)
curl -X POST -d "secret stuff" https://ig.lc/create?secure=true
```