### PR TITLE
feat: increase paste ID length to 7 characters

### DIFF
--- a/main.go
+++ b/main.go
@@ -167,7 +167,7 @@ func handleRequest(conn net.Conn) {
 	identifier := ""
 	tried := 0
 	for {
-		identifier = randString(4)
+		identifier = randString(7)
 		val, err := client.Get("pastey_" + identifier).Result()
 		if err != nil {
 			if err == redis.Nil {


### PR DESCRIPTION
## Summary
- Increases paste ID length from 4 to 7 characters for TCP-created pastes
- Reduces collision probability and improves namespace capacity
- Existing pastes remain accessible (backward compatible)